### PR TITLE
Update build script

### DIFF
--- a/.github/install-instructions-template.md
+++ b/.github/install-instructions-template.md
@@ -1,6 +1,6 @@
 
 # Installation Instructions
-- Download the archive "Carnalitas.${{ github.event.inputs.version }}.zip" and extract it somewhere
+- Download the archive "Carnalitas.VAR_VERSION.zip" and extract it somewhere
 - Go to your mod folder. On Windows this is in C:\Users\[your username]\Documents\Paradox Interactive\Crusader Kings III\mod\
 - Copy the content of the archive ("Carnalitas" folder and "Carnalitas.mod" file) into the mod folder.
   > If you are updating the mod, delete the old "Carnalitas" folder present in the mod folder before copying.

--- a/.github/install-instructions-template.md
+++ b/.github/install-instructions-template.md
@@ -1,0 +1,8 @@
+
+# Installation Instructions
+- Download the archive "Carnalitas.${{ github.event.inputs.version }}.zip" and extract it somewhere
+- Go to your mod folder. On Windows this is in C:\Users\[your username]\Documents\Paradox Interactive\Crusader Kings III\mod\
+- Copy the content of the archive ("Carnalitas" folder and "Carnalitas.mod" file) into the mod folder.
+  > If you are updating the mod, delete the old "Carnalitas" folder present in the mod folder before copying.
+- In your CK3 launcher go to Mods > Manage Mods > Add More Mods (in bottom right corner) > Select this mod and add it.
+- Restart your launcher if it doesn't show up in the list when you try to add it.

--- a/.github/workflows/build-and-draft-release.yml
+++ b/.github/workflows/build-and-draft-release.yml
@@ -5,8 +5,14 @@
 
 name: Build and draft release
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
+# Environment variables
+env:
+  # Paths are relative to the root folder of the repository
+  changelog_path: changelog.txt
+  install_instructions_path: .github/install-instructions-template.md
+  
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI or API.
 on:
   workflow_dispatch:
     # Inputs the workflow accepts.
@@ -22,18 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    # Checkout the repository into the building environment
+    # Checkout the repository to the building environment, into a "Carnalitas" folder
     - name: Checkout code
       uses: actions/checkout@v2
       with:
         path: Carnalitas
     
     # Create the Carnalitas.mod file
-    - name: Copy descriptor.mod content
-      run: cp ${{ github.workspace }}/Carnalitas/descriptor.mod ${{ github.workspace }}/Carnalitas.mod
-      
     - name: Create Carnalitas.mod file
-      run: echo -e '\npath="mod/Carnalitas"' >> Carnalitas.mod  
+      run: |
+        cp ${{ github.workspace }}/Carnalitas/descriptor.mod ${{ github.workspace }}/Carnalitas.mod
+        echo -e '\npath="mod/Carnalitas"' >> Carnalitas.mod  
     
     # Build the mod and upload it as an artifact to be used later (the paths starting with ! are excluded)
     # Note: the artifact is basically the mod, but unzipped
@@ -54,15 +59,19 @@ jobs:
       id: download
       with:
         name: Carnalitas.${{ github.event.inputs.version }}
-        path: ./Release/
+        path: ${{ github.workspace }}/Release/
         
     # Compress the artifact into a zip
     - name: Compress artifact to zip
-      run: zip -r ./Carnalitas.${{ github.event.inputs.version }}.zip ./Release/*
+      run: |
+        cd ${{ github.workspace }}/Release/
+        zip -r ${{ github.workspace }}/Carnalitas.${{ github.event.inputs.version }}.zip *
     
     # Append Installation Instructions to the release message
     - name: Append Installation Instructions to the release message
-      run:  cat ${{ github.workspace }}/Carnalitas/.github/install-instructions-template.md >> ${{ github.workspace }}/Carnalitas/changelog.txt
+      run:  cat ${{ github.workspace }}/Carnalitas/${{env.install_instructions_path}} >> ${{ github.workspace }}/Carnalitas/${{env.changelog_path}}  
+    - name: change the variable VAR_VERSION to the actual version in the release notes
+      run: sed -i 's/VAR_VERSION/${{ github.event.inputs.version }}/g' ${{ github.workspace }}/Carnalitas/${{env.changelog_path}}
 
     # Create the release on github 
     - name: Create Release
@@ -73,7 +82,7 @@ jobs:
       with:
         tag_name: ${{ github.event.inputs.version }}
         release_name: Carnalitas ${{ github.event.inputs.version }}
-        body_path: ${{ github.workspace }}/Carnalitas/changelog.txt
+        body_path: ${{ github.workspace }}/Carnalitas/${{env.changelog_path}}
         draft: true
         prerelease: false
 
@@ -85,6 +94,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./Carnalitas.${{ github.event.inputs.version }}.zip
+        asset_path: ${{ github.workspace }}/Carnalitas.${{ github.event.inputs.version }}.zip
         asset_name: Carnalitas.${{ github.event.inputs.version }}.zip
         asset_content_type: application/zip

--- a/.github/workflows/build-and-draft-release.yml
+++ b/.github/workflows/build-and-draft-release.yml
@@ -1,5 +1,7 @@
 # This is the build script for the Carnalitas mod
 # It creates the Carnalitas.mod file based on the descriptor.mod, and compresses it alongside the mod folder into a properly named archive
+# It then create a draft release prefilled with the content of "changelog.txt" and installation instructions
+# Note: All changes to files made by this script are done on a building environment hosted by github, not on the actual Carnalitas repository (except the draft release of course)
 
 name: Build and draft release
 
@@ -57,6 +59,10 @@ jobs:
     # Compress the artifact into a zip
     - name: Compress artifact to zip
       run: zip -r ./Carnalitas.${{ github.event.inputs.version }}.zip ./Release/*
+    
+    # Append Installation Instructions to the release message
+    - name: Append Installation Instructions to the release message
+      run:  cat ${{ github.workspace }}/Carnalitas/.github/install-instructions-template.md >> ${{ github.workspace }}/Carnalitas/changelog.txt
 
     # Create the release on github 
     - name: Create Release
@@ -67,17 +73,7 @@ jobs:
       with:
         tag_name: ${{ github.event.inputs.version }}
         release_name: Carnalitas ${{ github.event.inputs.version }}
-        body: |
-          ## Changes
-          <!--- Add the changes made for this version (new features, changes, fixes) -->
-
-          ## Installation Instructions
-          - Download the archive "Carnalitas.${{ github.event.inputs.version }}.zip" and extract it somewhere
-          - Go to your mod folder. On Windows this is in C:\Users\[your username]\Documents\Paradox Interactive\Crusader Kings III\mod\
-          - Copy the content of the archive ("Carnalitas" folder and "Carnalitas.mod" file) into the mod folder.
-            > If you are updating the mod, delete the old "Carnalitas" folder present in the mod folder before copying.
-          - In your CK3 launcher go to Mods > Manage Mods > Add More Mods (in bottom right corner) > Select this mod and add it.
-          - Restart your launcher if it doesn't show up in the list when you try to add it.
+        body_path: ${{ github.workspace }}/Carnalitas/changelog.txt
         draft: true
         prerelease: false
 


### PR DESCRIPTION
## Description
- Update the script to automatically add the changelog and install instructions to the release notes.
- Fix the zip which was including the mod folder and .mod file into a parent file and not at the root of the zip (bug was introduce during the last script update, so no releases were built with this bug)
- Add variables for the changelog path and install instructions template path, so it's easier to change them in the future if needed