### PR TITLE
Change game rules to use some dynamic trait names

### DIFF
--- a/localization/english/carn_game_rules_l_english.yml
+++ b/localization/english/carn_game_rules_l_english.yml
@@ -2,9 +2,9 @@
 
  rule_carn_std: "#X Carnalitas:#! STD Transmission"
  setting_carn_std_enabled: "Default"
- setting_carn_std_enabled_desc: "No changes will be made to Lover's Pox and the Great Pox."
+ setting_carn_std_enabled_desc: "No changes will be made to $trait_lovers_pox$ and the $trait_great_pox$."
  setting_carn_std_disabled: "#high Never#!"
- setting_carn_std_disabled_desc: "Characters will never contract Lover's Pox or the Great Pox."
+ setting_carn_std_disabled_desc: "Characters will never contract $trait_lovers_pox$ or the $trait_great_pox$."
 
  rule_carn_sex_interaction: "#X Carnalitas:#! Lay With Lover"
  setting_carn_sex_interaction_disabled: "Disabled"
@@ -18,7 +18,7 @@
  setting_carn_arousal_stress_disabled: "Disabled"
  setting_carn_arousal_stress_disabled_desc: "Characters will not naturally gain stress over time. This may cause slight balance issues if you frequently lay with your lovers."
  setting_carn_arousal_stress_enabled: "#high Enabled#!"
- setting_carn_arousal_stress_enabled_desc: "Characters naturally gain stress over time based on traits such as Rakish, Chaste, etc."
+ setting_carn_arousal_stress_enabled_desc: "Characters naturally gain stress over time based on traits such as $trait_rakish$, $trait_chaste$, etc."
 
  rule_carn_dt_enabled: "#X Carnalitas:#! Body Part Traits"
  setting_carn_dt_enabled_false: "Disabled"
@@ -28,15 +28,15 @@
 
  rule_carn_dt_trait_names: "#X Carnalitas:#! Body Part Trait Names"
  setting_carn_dt_trait_names_default: "Default"
- setting_carn_dt_trait_names_default_desc: "The breast and penis size traits of characters will be named 'Big Tits,' 'Huge Dick,' and so on."
+ setting_carn_dt_trait_names_default_desc: "The breast and penis size traits of characters will be named '$trait_tits_big_1$', '$trait_dick_big_1$', and so on."
  setting_carn_dt_trait_names_immersive: "#high Immersive#!"
- setting_carn_dt_trait_names_immersive_desc: "The breast and penis size traits of characters will be named 'Bosomy,' 'Horse-Hung,' and so on."
+ setting_carn_dt_trait_names_immersive_desc: "The breast and penis size traits of characters will be named '$trait_tits_big_1_immersive$', '$trait_dick_big_1_immersive$', and so on."
 
  rule_carn_futa_trait_name: "#X Carnalitas:#! Futanari Trait Name"
  setting_carn_futa_trait_name_futa: "Default"
- setting_carn_futa_trait_name_futa_desc: "Women with both male and female sexual organs will be called 'futanari.'"
+ setting_carn_futa_trait_name_futa_desc: "Women with both male and female sexual organs will be called '$trait_futa$'."
  setting_carn_futa_trait_name_hermaphrodite: "#high Immersive#!"
- setting_carn_futa_trait_name_hermaphrodite_desc: "Women with both male and female sexual organs will be called 'hermaphrodites.'"
+ setting_carn_futa_trait_name_hermaphrodite_desc: "Women with both male and female sexual organs will be called '$trait_futa_immersive$'"
 
  rule_carn_futa_content: "#X Carnalitas:#! Futanari Content"
  setting_carn_futa_content_disabled: "Disabled"


### PR DESCRIPTION
<!--- Take the time to look at the right-hand column and fill in the relevant information (Reviewers, Labels, Project, Linked issues...).  -->

## Types of changes
<!--- What types of changes does your code introduce? Replace the space by an `x` in all the boxes that apply: -->
- [x] I have read the [Contributing file](https://github.com/cherisong/Carnalitas/blob/development/CONTRIBUTING.md)
- [x] New feature (non-breaking change which adds functionality)

## Description
Change game rules to use some dynamic trait names, like `$trait_tits_big_1$` instead of `Big Tits`
That way we won't have to change the loc later if we decide to change some of these traits name.
