### PR TITLE
Basic dominant/submissive relation

### DIFF
--- a/common/game_concepts/carn_game_concepts.txt
+++ b/common/game_concepts/carn_game_concepts.txt
@@ -1,0 +1,9 @@
+﻿dominant = {
+	alias = { dominants dominant_possessive dominants_possessive }
+	parent = relation
+}
+
+submissive = {
+	alias = { submissives submissive_possessive submissives_possessive }
+	parent = relation
+}

--- a/common/game_concepts/carn_game_concepts.txt
+++ b/common/game_concepts/carn_game_concepts.txt
@@ -1,9 +1,9 @@
 ﻿dominant = {
-	alias = { dominants dominant_possessive dominants_possessive }
+	alias = { dominant_short dominants dominant_possessive dominants_possessive }
 	parent = relation
 }
 
 submissive = {
-	alias = { submissives submissive_possessive submissives_possessive }
+	alias = { submissive_short submissives submissive_possessive submissives_possessive }
 	parent = relation
 }

--- a/common/scripted_relations/carn_scripted_relations.txt
+++ b/common/scripted_relations/carn_scripted_relations.txt
@@ -1,0 +1,10 @@
+# a dominant has a submissive, and vice-versa
+dominant = {
+  corresponding = submissive
+  opinion = 20
+}
+
+submissive = {
+  corresponding = dominant
+  opinion = 20
+}

--- a/common/scripted_relations/carn_scripted_relations.txt
+++ b/common/scripted_relations/carn_scripted_relations.txt
@@ -1,10 +1,10 @@
-# a dominant has a submissive, and vice-versa
+﻿# a dominant has a submissive, and vice-versa
 dominant = {
   corresponding = submissive
-  opinion = 20
+  opinion = 10
 }
 
 submissive = {
   corresponding = dominant
-  opinion = 20
+  opinion = 10
 }

--- a/common/scripted_triggers/carn_relation_triggers.txt
+++ b/common/scripted_triggers/carn_relation_triggers.txt
@@ -1,0 +1,31 @@
+﻿### BDSM ###
+
+## dominant and submissive relations are mutually-exclusive between the same two
+## characters, i.e. character A cannot be both the dominant and submissive of
+## character B
+
+can_set_relation_dominant_trigger = {
+	is_adult = yes
+	is_attracted_to_gender_of = $CHARACTER$
+	$CHARACTER$ = {
+		is_adult = yes
+		is_attracted_to_gender_of = prev
+	}
+	NOR = {
+    has_relation_dominant = $CHARACTER$
+    has_relation_submissive = $CHARACTER$
+  }
+}
+
+can_set_relation_submissive_trigger = {
+	is_adult = yes
+	is_attracted_to_gender_of = $CHARACTER$
+	$CHARACTER$ = {
+		is_adult = yes
+		is_attracted_to_gender_of = prev
+	}
+	NOR = {
+    has_relation_dominant = $CHARACTER$
+    has_relation_submissive = $CHARACTER$
+  }
+}

--- a/localization/english/carn_game_concepts_l_english.yml
+++ b/localization/english/carn_game_concepts_l_english.yml
@@ -1,13 +1,15 @@
 ﻿l_english:
 
  game_concept_dominant: "Dominant"
+ game_concept_dominant_short: "Dom"
  game_concept_dominants: "Dominants"
  game_concept_dominant_possessive: "Dominant's"
  game_concept_dominants_possessive: "Dominants'"
- game_concept_dominant_desc: "Often shortened to Dom, a $game_concept_dominant$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding $game_concept_submissive$. While specifics vary, the role of [dominant|E] typically involves in some way commanding or assuming control over the [submissive|E]."
+ game_concept_dominant_desc: "Often shortened to $game_concept_dominant_short$, a $game_concept_dominant$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding [submissive|E]. While specifics vary, the role of $game_concept_dominant$ typically involves in some way commanding or assuming control over the $game_concept_submissive$."
 
  game_concept_submissive: "Submissive"
+ game_concept_submissive_short: "Sub"
  game_concept_submissives: "Submissives"
  game_concept_submissive_possessive: "Submissive's"
  game_concept_submissives_possessive: "Submissives'"
- game_concept_submissive_desc: "Often shortened to Sub, a $game_concept_submissive$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding $game_concept_dominant$. While specifics vary, the role of [submissive|E] typically involves in some way obeying or surrendering control to the [dominant|E]."
+ game_concept_submissive_desc: "Often shortened to $game_concept_submissive_short$, a $game_concept_submissive$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding [dominant|E]. While specifics vary, the role of $game_concept_submissive$ typically involves in some way obeying or surrendering control to the $game_concept_dominant$."

--- a/localization/english/carn_game_concepts_l_english.yml
+++ b/localization/english/carn_game_concepts_l_english.yml
@@ -8,7 +8,7 @@
  game_concept_dominant_desc: "Often shortened to $game_concept_dominant_short$, a $game_concept_dominant$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding [submissive|E]. While specifics vary, the role of $game_concept_dominant$ typically involves in some way commanding or assuming control over the $game_concept_submissive$."
 
  game_concept_submissive: "Submissive"
- game_concept_submissive: "Submissive"
+ game_concept_submissive_short: "Sub"
  game_concept_submissives: "Submissives"
  game_concept_submissive_possessive: "Submissive's"
  game_concept_submissives_possessive: "Submissives'"

--- a/localization/english/carn_game_concepts_l_english.yml
+++ b/localization/english/carn_game_concepts_l_english.yml
@@ -1,11 +1,13 @@
 ﻿l_english:
 
  game_concept_dominant: "Dominant"
+ game_concept_dominant_short: "Dom"
  game_concept_dominants: "Dominants"
  game_concept_dominant_possessive: "Dominant's"
  game_concept_dominants_possessive: "Dominants'"
  game_concept_dominant_desc: "Often shortened to $game_concept_dominant_short$, a $game_concept_dominant$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding [submissive|E]. While specifics vary, the role of $game_concept_dominant$ typically involves in some way commanding or assuming control over the $game_concept_submissive$."
 
+ game_concept_submissive: "Submissive"
  game_concept_submissive: "Submissive"
  game_concept_submissives: "Submissives"
  game_concept_submissive_possessive: "Submissive's"

--- a/localization/english/carn_game_concepts_l_english.yml
+++ b/localization/english/carn_game_concepts_l_english.yml
@@ -1,14 +1,12 @@
 ﻿l_english:
 
  game_concept_dominant: "Dominant"
- game_concept_dominant_short: "Dom"
  game_concept_dominants: "Dominants"
  game_concept_dominant_possessive: "Dominant's"
  game_concept_dominants_possessive: "Dominants'"
  game_concept_dominant_desc: "Often shortened to $game_concept_dominant_short$, a $game_concept_dominant$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding [submissive|E]. While specifics vary, the role of $game_concept_dominant$ typically involves in some way commanding or assuming control over the $game_concept_submissive$."
 
  game_concept_submissive: "Submissive"
- game_concept_submissive_short: "Sub"
  game_concept_submissives: "Submissives"
  game_concept_submissive_possessive: "Submissive's"
  game_concept_submissives_possessive: "Submissives'"

--- a/localization/english/carn_game_concepts_l_english.yml
+++ b/localization/english/carn_game_concepts_l_english.yml
@@ -1,0 +1,13 @@
+﻿l_english:
+
+ game_concept_dominant: "Dominant"
+ game_concept_dominants: "Dominants"
+ game_concept_dominant_possessive: "Dominant's"
+ game_concept_dominants_possessive: "Dominants'"
+ game_concept_dominant_desc: "Often shortened to Dom, a $game_concept_dominant$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding $game_concept_submissive$. While specifics vary, the role of [dominant|E] typically involves in some way commanding or assuming control over the [submissive|E]."
+
+ game_concept_submissive: "Submissive"
+ game_concept_submissives: "Submissives"
+ game_concept_submissive_possessive: "Submissive's"
+ game_concept_submissives_possessive: "Submissives'"
+ game_concept_submissive_desc: "Often shortened to Sub, a $game_concept_submissive$ is a $game_concept_character$ with a $game_concept_relation$ to a corresponding $game_concept_dominant$. While specifics vary, the role of [submissive|E] typically involves in some way obeying or surrendering control to the [dominant|E]."

--- a/localization/english/carn_relations_l_english.yml
+++ b/localization/english/carn_relations_l_english.yml
@@ -1,0 +1,4 @@
+﻿l_english:
+
+ dominant: "[dominant|E]"
+ submissive: "[submissive|E]"


### PR DESCRIPTION
<!--- Take the time to look at the right-hand column and fill in the relevant information (Reviewers, Labels, Project, Linked issues...).  -->

## Types of changes
<!--- What types of changes does your code introduce? Replace the space by an `x` in all the boxes that apply: -->
- [x] I have read the [Contributing file](https://github.com/cherisong/Carnalitas/blob/development/CONTRIBUTING.md)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. Likely not save-compatible)
- [ ] I have added a summary of the change to the changelog.txt file
- [x] My change requires a change to the documentation/wiki.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe or list the changes you made -->
Adds a new relation type and associated localization and relation_trigger. The new relation has two sides, similar to guardian/ward: dominant and submissive.

The relation_trigger makes the relations mutually exclusive, so someone cannot be both dominant and submissive to the same character. Easy to override in another mod if someone wants to.

Also please ignore the messy commits, not used to using Git on Windows