### PR TITLE
Fixed empty warning when trying to grant titles to a slave

### DIFF
--- a/localization/english/carn_triggers_l_english.yml
+++ b/localization/english/carn_triggers_l_english.yml
@@ -2,6 +2,6 @@
  carn_i_can_be_granted_titles: "You can be granted [titles|E]"
  carn_not_i_can_be_granted_titles: "You cannot be granted [titles|E]"
  carn_they_can_be_granted_titles: "[CHARACTER.GetShortUIName|U] can be granted [titles|E]"
- carn_not_they_can_be_granted_titles: "[CHARACTER.GetShortUIName|U] cannot be granted 
+ carn_not_they_can_be_granted_titles: "[CHARACTER.GetShortUIName|U] cannot be granted [titles|E]"
  carn_can_be_granted_titles: "Can be granted [titles|E]"
  carn_not_can_be_granted_titles: "Cannot be granted [titles|E]"

--- a/localization/french/carn_triggers_l_french.yml
+++ b/localization/french/carn_triggers_l_french.yml
@@ -2,6 +2,6 @@
  carn_i_can_be_granted_titles: "Vous pouvez vous voir attribuer des [titles|El]"
  carn_not_i_can_be_granted_titles: "Vous ne pouvez pas vous voir attribuer de [titles|El]"
  carn_they_can_be_granted_titles: "[CHARACTER.Custom('FR_only_le_GetShortUIName')|U][CHARACTER.GetShortUIName|V] peut se voir attribuer des [titles|El]"
- carn_not_they_can_be_granted_titles: "[CHARACTER.Custom('FR_only_le_GetShortUIName')|U][CHARACTER.GetShortUIName|V] ne peut pas se voir attribuer de [titles|El]
+ carn_not_they_can_be_granted_titles: "[CHARACTER.Custom('FR_only_le_GetShortUIName')|U][CHARACTER.GetShortUIName|V] ne peut pas se voir attribuer de [titles|El]"
  carn_can_be_granted_titles: "Peut se voir attribuer des [titles|El]"
  carn_not_can_be_granted_titles: "Ne peut pas se voir attribuer de [titles|El]"


### PR DESCRIPTION
<!--- Take the time to look at the right-hand column and fill in the relevant information (Reviewers, Labels, Project, Linked issues...).  -->

## Types of changes
<!--- What types of changes does your code introduce? Replace the space by an `x` in all the boxes that apply: -->
- [x] I have read the [Contributing file](https://github.com/cherisong/Carnalitas/blob/development/CONTRIBUTING.md)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Localization change (Your changes mainly concern localization)

## Description
<!--- Describe or list the changes you made -->
The "[...] can not be granted titles" warning now correctly displays in-game. Closes #39 