### PR TITLE
Fixed STDs spreading when disabled by game rule

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@
 
 * **IMPORTANT:** `carn_sex_scene_effect` now also requires argument `DRAMA` (boolean). It passes this argument to the requested event, which should check for it and apply it to `carn_had_sex_with_effect` as appropriate.
 * `carn_had_sex_effect` now returns `scope:carn_sex_char_1_impregnated`, `scope:carn_sex_char_2_impregnated`. These are yes if the character was impregnated through the sex effect, and no otherwise.
-` New sex scene tag: `orgy`
+* New sex scene tag: `orgy`
 * `carn_on_sex` now provides `scope:carn_sex_partner`.
 * New scripted effect: `carn_enslave_effect`. This gives the Slave trait to a character, forces them to abdicate, and makes them the Slave (relation) of another character. Takes arguments `SLAVE`, `OWNER`, `DRAMA`
 * New scripted effect: `carn_free_slave_effect`. Changes the Slave trait to Former Slave and removes their Owner (which will also remove the hook their Owner has on them).
@@ -34,3 +34,4 @@
 * Fixed tooltip not displaying for `carn_can_grant_titles_trigger`.
 * Fixed sex scenes being possible to display even if their tags are turned off in game rules.
 * Fixed tits_big and dick_big traits being flagged as bad traits.
+* Fixed STDs being transmitted even when disabled by game rule.

--- a/common/scripted_triggers/carn_20_health_triggers_overwrite.txt
+++ b/common/scripted_triggers/carn_20_health_triggers_overwrite.txt
@@ -8,6 +8,11 @@ can_contract_disease_trigger = {
 	#Doesn't already have the trait
 	NOT = { has_trait = $DISEASE$ }
 
+	save_temporary_scope_value_as = {
+		name = disease_type_for_trigger
+		value = flag:$DISEASE$
+	}
+
 	#Carnalitas: Can't contract STDs if STD Transmission game rule is Never
 	trigger_if = {
 		limit = {
@@ -20,11 +25,6 @@ can_contract_disease_trigger = {
 			scope:disease_type_for_trigger = flag:lovers_pox
 			scope:disease_type_for_trigger = flag:great_pox
 		}
-	}
-
-	save_temporary_scope_value_as = {
-		name = disease_type_for_trigger
-		value = flag:$DISEASE$
 	}
 
 	trigger_if = { #Lover's pox can only be contracted if you are sexually active


### PR DESCRIPTION
<!--- Take the time to look at the right-hand column and fill in the relevant information (Reviewers, Labels, Project, Linked issues...).  -->

## Types of changes
<!--- What types of changes does your code introduce? Replace the space by an `x` in all the boxes that apply: -->
- [x] I have read the [Contributing file](https://github.com/cherisong/Carnalitas/blob/development/CONTRIBUTING.md)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have added a summary of the change to the changelog.md file

## Description
<!--- Describe or list the changes you made -->
Fixed #49 where the game would produce an error instead of preventing a character from contracting an STD. This is the same bug as the one seeker0003 reported on LoversLab.